### PR TITLE
Filter accessibles by tags

### DIFF
--- a/survey/filters.py
+++ b/survey/filters.py
@@ -599,18 +599,23 @@ class SampleStateFilter(StateFilter):
     ]
 
 
-class PortfolioSearchFilter(SearchFilter):
-
-    tags_field = 'extra_tags_str'
+class JSONArraySearchFilter(SearchFilter):
 
     def get_valid_fields(self, request, queryset, view, context=None):
         fields = super().get_valid_fields(
             request, queryset, view, context=context)
-        if self.tags_field not in fields:
-            fields = fields + (self.tags_field,)
+        for field in getattr(view, 'json_search_fields', []):
+            if field not in fields:
+                fields = fields + (field,)
         return fields
 
     def build_search_query(self, orm_lookup, search_term):
-        if orm_lookup.startswith(self.tags_field):
-            return models.Q(**{orm_lookup: f'"{search_term}"'})
+        json_search_fields = getattr(self, '_json_search_fields', ())
+        for field in json_search_fields:
+            if orm_lookup.startswith(field):
+                return models.Q(**{orm_lookup: f'"{search_term}"'})
         return super().build_search_query(orm_lookup, search_term)
+
+    def filter_queryset(self, request, queryset, view):
+        self._json_search_fields = getattr(view, 'json_search_fields', ())
+        return super().filter_queryset(request, queryset, view)

--- a/survey/filters.py
+++ b/survey/filters.py
@@ -28,8 +28,7 @@ from functools import reduce
 
 from django.core.exceptions import FieldDoesNotExist
 from django.db import models
-from django.db.models import JSONField, Q, TextField
-from django.db.models.functions import Cast, TruncMonth, TruncYear
+from django.db.models.functions import TruncMonth, TruncYear
 from django.db.models.query import RawQuerySet
 from rest_framework.filters import (OrderingFilter as BaseOrderingFilter,
     SearchFilter as BaseSearchFilter, BaseFilterBackend)
@@ -103,7 +102,7 @@ class SearchFilter(BaseSearchFilter):
         conditions = []
         for search_term in search_terms:
             queries = [
-                models.Q(**{orm_lookup: search_term})
+                self.build_search_query(orm_lookup, search_term)
                 for orm_lookup in orm_lookups
             ]
             conditions.append(reduce(operator.or_, queries))
@@ -116,6 +115,10 @@ class SearchFilter(BaseSearchFilter):
             # We try to avoid this if possible, for performance reasons.
             queryset = queryset.distinct()
         return queryset
+
+
+    def build_search_query(self, orm_lookup, search_term):
+        return models.Q(**{orm_lookup: search_term})
 
 
     def filter_valid_fields(self, queryset, fields, view):
@@ -596,46 +599,18 @@ class SampleStateFilter(StateFilter):
     ]
 
 
-class PortfolioTagsFilter(BaseFilterBackend):
+class PortfolioSearchFilter(SearchFilter):
 
-    tags_param = 'tags'
+    tags_field = 'extra_tags_str'
 
-    def get_query_param(self, request, key, default_value=None):
-        try:
-            return request.query_params.get(key, default_value)
-        except AttributeError:
-            pass
-        return request.GET.get(key, default_value)
+    def get_valid_fields(self, request, queryset, view, context=None):
+        fields = super().get_valid_fields(
+            request, queryset, view, context=context)
+        if self.tags_field not in fields:
+            fields = fields + (self.tags_field,)
+        return fields
 
-    def filter_queryset(self, request, queryset, view):
-        tags_qs = self.get_query_param(request, self.tags_param, '')
-        tags = None
-        if tags_qs:
-            tags = []
-            for tag in tags_qs.split(','):
-                tag = tag.strip()
-                if tag:
-                    tags.append(tag)
-        if not tags:
-            return queryset
-        queryset = queryset.annotate(
-            extra_json=Cast('portfolios__extra', output_field=JSONField()),
-            extra_tags_str=Cast('extra_json__tags', TextField()),
-        )
-        tags_filter = Q()
-        for tag in tags:
-            tags_filter &= Q(extra_tags_str__contains=f'"{tag}"')
-        return queryset.filter(tags_filter)
-
-    def get_schema_operation_parameters(self, view):
-        return [
-            {
-                'name': self.tags_param,
-                'required': False,
-                'in': 'query',
-                'description': force_str("filter by portfolio tags"),
-                'schema': {
-                    'type': 'string',
-                },
-            },
-        ]
+    def build_search_query(self, orm_lookup, search_term):
+        if orm_lookup.startswith(self.tags_field):
+            return models.Q(**{orm_lookup: f'"{search_term}"'})
+        return super().build_search_query(orm_lookup, search_term)

--- a/survey/filters.py
+++ b/survey/filters.py
@@ -28,7 +28,8 @@ from functools import reduce
 
 from django.core.exceptions import FieldDoesNotExist
 from django.db import models
-from django.db.models.functions import TruncMonth, TruncYear
+from django.db.models import JSONField, Q, TextField
+from django.db.models.functions import Cast, TruncMonth, TruncYear
 from django.db.models.query import RawQuerySet
 from rest_framework.filters import (OrderingFilter as BaseOrderingFilter,
     SearchFilter as BaseSearchFilter, BaseFilterBackend)
@@ -593,3 +594,48 @@ class SampleStateFilter(StateFilter):
         (False, 'active'),
         (True, 'completed')
     ]
+
+
+class PortfolioTagsFilter(BaseFilterBackend):
+
+    tags_param = 'tags'
+
+    def get_query_param(self, request, key, default_value=None):
+        try:
+            return request.query_params.get(key, default_value)
+        except AttributeError:
+            pass
+        return request.GET.get(key, default_value)
+
+    def filter_queryset(self, request, queryset, view):
+        tags_qs = self.get_query_param(request, self.tags_param, '')
+        tags = None
+        if tags_qs:
+            tags = []
+            for tag in tags_qs.split(','):
+                tag = tag.strip()
+                if tag:
+                    tags.append(tag)
+        if not tags:
+            return queryset
+        queryset = queryset.annotate(
+            extra_json=Cast('portfolios__extra', output_field=JSONField()),
+            extra_tags_str=Cast('extra_json__tags', TextField()),
+        )
+        tags_filter = Q()
+        for tag in tags:
+            tags_filter &= Q(extra_tags_str__contains=f'"{tag}"')
+        return queryset.filter(tags_filter)
+
+    def get_schema_operation_parameters(self, view):
+        return [
+            {
+                'name': self.tags_param,
+                'required': False,
+                'in': 'query',
+                'description': force_str("filter by portfolio tags"),
+                'schema': {
+                    'type': 'string',
+                },
+            },
+        ]

--- a/survey/utils.py
+++ b/survey/utils.py
@@ -36,8 +36,6 @@ from django.conf import settings as django_settings
 from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.core.exceptions import ImproperlyConfigured
 from django.db import models
-from django.db.models import JSONField, Q, TextField
-from django.db.models.functions import Cast
 from django.http.request import split_domain_port, validate_host
 from rest_framework.exceptions import ValidationError
 
@@ -51,7 +49,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 def get_accessible_accounts(grantees, campaign=None, aggregate_set=False,
-                            start_at=None, ends_at=None, tags=None):
+                            start_at=None, ends_at=None, **filter_kwargs):
     """
     All accounts which have elected to share samples with at least one
     account in grantees.
@@ -66,10 +64,11 @@ def get_accessible_accounts(grantees, campaign=None, aggregate_set=False,
         settings.ACCESSIBLE_ACCOUNTS_CALLABLE):
         queryset = import_string(settings.ACCESSIBLE_ACCOUNTS_CALLABLE)(
             grantees, campaign=campaign, aggregate_set=aggregate_set,
-            start_at=start_at, ends_at=ends_at)
+            start_at=start_at, ends_at=ends_at, **filter_kwargs)
 
     if queryset is None:
         filter_params = {}
+        filter_params.update(filter_kwargs)
         if start_at:
             # XXX not sure anymore why we use double-optin here...
             filter_params.update({
@@ -88,17 +87,6 @@ def get_accessible_accounts(grantees, campaign=None, aggregate_set=False,
 
         if not aggregate_set:
             queryset = queryset.annotate(_extra=models.F('portfolios__extra'))
-
-        if tags:
-            queryset = queryset.annotate(
-                extra_json=Cast('portfolios__extra', output_field=JSONField()),
-                extra_tags_str=Cast('extra_json__tags', TextField()),
-            )
-            tags_filter = Q()
-            for tag in tags:
-                tags_filter &= Q(extra_tags_str__contains=f'"{tag}"')
-            queryset = queryset.filter(tags_filter)
-
         queryset = queryset.distinct()
 
     return queryset

--- a/survey/utils.py
+++ b/survey/utils.py
@@ -49,7 +49,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 def get_accessible_accounts(grantees, campaign=None, aggregate_set=False,
-                            start_at=None, ends_at=None, **filter_kwargs):
+                            start_at=None, ends_at=None):
     """
     All accounts which have elected to share samples with at least one
     account in grantees.
@@ -64,11 +64,10 @@ def get_accessible_accounts(grantees, campaign=None, aggregate_set=False,
         settings.ACCESSIBLE_ACCOUNTS_CALLABLE):
         queryset = import_string(settings.ACCESSIBLE_ACCOUNTS_CALLABLE)(
             grantees, campaign=campaign, aggregate_set=aggregate_set,
-            start_at=start_at, ends_at=ends_at, **filter_kwargs)
+            start_at=start_at, ends_at=ends_at)
 
     if queryset is None:
         filter_params = {}
-        filter_params.update(filter_kwargs)
         if start_at:
             # XXX not sure anymore why we use double-optin here...
             filter_params.update({
@@ -87,6 +86,7 @@ def get_accessible_accounts(grantees, campaign=None, aggregate_set=False,
 
         if not aggregate_set:
             queryset = queryset.annotate(_extra=models.F('portfolios__extra'))
+
         queryset = queryset.distinct()
 
     return queryset

--- a/survey/utils.py
+++ b/survey/utils.py
@@ -36,6 +36,8 @@ from django.conf import settings as django_settings
 from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.core.exceptions import ImproperlyConfigured
 from django.db import models
+from django.db.models import JSONField, Q, TextField
+from django.db.models.functions import Cast
 from django.http.request import split_domain_port, validate_host
 from rest_framework.exceptions import ValidationError
 
@@ -49,7 +51,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 def get_accessible_accounts(grantees, campaign=None, aggregate_set=False,
-                            start_at=None, ends_at=None):
+                            start_at=None, ends_at=None, tags=None):
     """
     All accounts which have elected to share samples with at least one
     account in grantees.
@@ -86,6 +88,16 @@ def get_accessible_accounts(grantees, campaign=None, aggregate_set=False,
 
         if not aggregate_set:
             queryset = queryset.annotate(_extra=models.F('portfolios__extra'))
+
+        if tags:
+            queryset = queryset.annotate(
+                extra_json=Cast('portfolios__extra', output_field=JSONField()),
+                extra_tags_str=Cast('extra_json__tags', TextField()),
+            )
+            tags_filter = Q()
+            for tag in tags:
+                tags_filter &= Q(extra_tags_str__contains=f'"{tag}"')
+            queryset = queryset.filter(tags_filter)
 
         queryset = queryset.distinct()
 


### PR DESCRIPTION
This PR adds functionality to filter accessibles by tags on the backend. The implementation is a bit convoluted. I wasn't sure what database is used in production (PG or SQLite or if both should be supported). The problem is that the `extra` field is a `TextField` and not `JSONField`, so I'm casting it to `JSONField`. Another issue is that SQLite doesn't support `__contains` lookups on `JSONField` so I'm basically retrieving the `tags` key from `extra`, convert the value to text and do a string literal search for each provided tag. If the prod uses PostgreSQL we can replace this with a `__contains` lookup. The other alternative would be to subclass `__contains` lookup class to add support for SQLite.