### PR TITLE
Add support for multiple recipients for "re-send" invitation

### DIFF
--- a/survey/api/portfolios.py
+++ b/survey/api/portfolios.py
@@ -593,6 +593,7 @@ class PortfoliosRequestsAPIView(SmartPortfolioListMixin,
                 'ends_at': serializer.validated_data.get('ends_at')})
         campaign = serializer.validated_data.get('campaign')
         accounts = serializer.validated_data['accounts']
+        cc = serializer.validated_data.get('cc', [])
         requests_initiated = []
         with transaction.atomic():
             for serialized_account in accounts:
@@ -615,6 +616,14 @@ class PortfoliosRequestsAPIView(SmartPortfolioListMixin,
                     account_data.pop(field_name)
                 account, unused_created = account_model.objects.get_or_create(
                     defaults=account_data, **lookups)
+
+                email = serialized_account.get('email')
+                if not unused_created and not account.email:
+                    if email:
+                        account.email = email
+                        account.save(update_fields=['email'])
+                if email and account.email != email:
+                    cc.append(email)
 
                 # fill receipients information with additional information
                 # we can find in the database.
@@ -660,7 +669,7 @@ class PortfoliosRequestsAPIView(SmartPortfolioListMixin,
             recipients = req[1]
             signals.portfolios_request_initiated.send(sender=__name__,
                 portfolios=[portfolio], recipients=recipients, message=message,
-                request=self.request)
+                cc=cc, request=self.request)
 
         results = self.serializer_class(many=True,
             context=self.get_serializer_context()).to_representation(

--- a/survey/api/portfolios.py
+++ b/survey/api/portfolios.py
@@ -596,14 +596,11 @@ class PortfoliosRequestsAPIView(SmartPortfolioListMixin,
         requests_initiated = []
         with transaction.atomic():
             for serialized_account in accounts:
-                emails = serialized_account.pop('email', [])
-                email = emails[0] if emails else None
-                cc = list(emails[1:]) if len(emails) > 1 else []
+                email = serialized_account.get('email')
+                cc = serialized_account.pop('recipients', [])
 
                 account_data = {}
                 account_data.update(serialized_account)
-                if email:
-                    account_data['email'] = email
 
                 # Django1.11: we need to remove invalid fields when creating
                 # a new grantee account otherwise Django1.11 will raise
@@ -664,19 +661,18 @@ class PortfoliosRequestsAPIView(SmartPortfolioListMixin,
                     verification_key=PortfolioDoubleOptIn.generate_key(account),
                         **defaults)
                     status_code = status.HTTP_201_CREATED
-                requests_initiated += [(
-                    portfolio,
-                    [account_data] if account_data else [],
-                    cc)]
+                recipients = (
+                    ([account_data] if account_data else []) +
+                    [{'email': cc_email} for cc_email in cc])
+                requests_initiated += [(portfolio, recipients)]
 
         message = serializer.validated_data.get('message')
         for req in requests_initiated:
             portfolio = req[0]
             recipients = req[1]
-            account_cc = req[2]
             signals.portfolios_request_initiated.send(sender=__name__,
                 portfolios=[portfolio], recipients=recipients, message=message,
-                cc=account_cc, request=self.request)
+                request=self.request)
 
         results = self.serializer_class(many=True,
             context=self.get_serializer_context()).to_representation(

--- a/survey/api/portfolios.py
+++ b/survey/api/portfolios.py
@@ -593,12 +593,17 @@ class PortfoliosRequestsAPIView(SmartPortfolioListMixin,
                 'ends_at': serializer.validated_data.get('ends_at')})
         campaign = serializer.validated_data.get('campaign')
         accounts = serializer.validated_data['accounts']
-        cc = serializer.validated_data.get('cc', [])
         requests_initiated = []
         with transaction.atomic():
             for serialized_account in accounts:
+                emails = serialized_account.pop('email', [])
+                email = emails[0] if emails else None
+                cc = list(emails[1:]) if len(emails) > 1 else []
+
                 account_data = {}
                 account_data.update(serialized_account)
+                if email:
+                    account_data['email'] = email
 
                 # Django1.11: we need to remove invalid fields when creating
                 # a new grantee account otherwise Django1.11 will raise
@@ -614,11 +619,10 @@ class PortfoliosRequestsAPIView(SmartPortfolioListMixin,
                         invalid_fields += [field_name]
                 for field_name in invalid_fields:
                     account_data.pop(field_name)
-                account, unused_created = account_model.objects.get_or_create(
+                account, account_created = account_model.objects.get_or_create(
                     defaults=account_data, **lookups)
 
-                email = serialized_account.get('email')
-                if not unused_created and not account.email:
+                if not account_created and not account.email:
                     if email:
                         account.email = email
                         account.save(update_fields=['email'])
@@ -661,15 +665,18 @@ class PortfoliosRequestsAPIView(SmartPortfolioListMixin,
                         **defaults)
                     status_code = status.HTTP_201_CREATED
                 requests_initiated += [(
-                    portfolio, [account_data] if account_data else [])]
+                    portfolio,
+                    [account_data] if account_data else [],
+                    cc)]
 
         message = serializer.validated_data.get('message')
         for req in requests_initiated:
             portfolio = req[0]
             recipients = req[1]
+            account_cc = req[2]
             signals.portfolios_request_initiated.send(sender=__name__,
                 portfolios=[portfolio], recipients=recipients, message=message,
-                cc=cc, request=self.request)
+                cc=account_cc, request=self.request)
 
         results = self.serializer_class(many=True,
             context=self.get_serializer_context()).to_representation(

--- a/survey/api/serializers.py
+++ b/survey/api/serializers.py
@@ -649,9 +649,18 @@ class PortfolioGrantCreateSerializer(serializers.ModelSerializer):
         read_only_fields = ("ends_at",)
 
 
+class InviteeWithCCSerializer(InviteeSerializer):
+
+    email = serializers.ListField(
+        child=serializers.EmailField(),
+        required=False, default=list,
+        help_text=_("Email addresses for the invitee. The first email"
+            " is the primary recipient, subsequent ones are CC'd"))
+
+
 class PortfolioRequestCreateSerializer(serializers.ModelSerializer):
 
-    accounts = InviteeSerializer(many=True)
+    accounts = InviteeWithCCSerializer(many=True)
     campaign = serializers.SlugRelatedField(required=False,
         queryset=Campaign.objects.all(), slug_field='slug')
     ends_at = serializers.DateTimeField(required=False, allow_null=True,
@@ -659,15 +668,10 @@ class PortfolioRequestCreateSerializer(serializers.ModelSerializer):
     extra = ExtraField(required=False,
         help_text=_("Extra meta data (can be stringify JSON)"))
     message = serializers.CharField(required=False, allow_null=True)
-    cc = serializers.ListField(
-        child=serializers.EmailField(),
-        required=False, default=list,
-        help_text=_("Additional email addresses"
-            " to notify besides the primary recipient"))
 
     class Meta:
         model = PortfolioDoubleOptIn
-        fields = ('accounts', 'campaign', 'ends_at', 'extra', 'message', 'cc')
+        fields = ('accounts', 'campaign', 'ends_at', 'extra', 'message')
 
 
 class PortfolioOptInUpdateSerializer(serializers.ModelSerializer):

--- a/survey/api/serializers.py
+++ b/survey/api/serializers.py
@@ -659,10 +659,15 @@ class PortfolioRequestCreateSerializer(serializers.ModelSerializer):
     extra = ExtraField(required=False,
         help_text=_("Extra meta data (can be stringify JSON)"))
     message = serializers.CharField(required=False, allow_null=True)
+    cc = serializers.ListField(
+        child=serializers.EmailField(),
+        required=False, default=list,
+        help_text=_("Additional email addresses"
+            " to notify besides the primary recipient"))
 
     class Meta:
         model = PortfolioDoubleOptIn
-        fields = ('accounts', 'campaign', 'ends_at', 'extra', 'message')
+        fields = ('accounts', 'campaign', 'ends_at', 'extra', 'message', 'cc')
 
 
 class PortfolioOptInUpdateSerializer(serializers.ModelSerializer):

--- a/survey/api/serializers.py
+++ b/survey/api/serializers.py
@@ -614,6 +614,11 @@ class InviteeSerializer(NoModelSerializer):
     slug = serializers.SlugField()
     full_name = serializers.CharField(required=False)
     email = serializers.EmailField(required=False)
+    recipients = serializers.ListField(
+        child=serializers.EmailField(),
+        required=False, default=list,
+        help_text=_("Additional email addresses"
+            " to notify besides the primary recipient"))
     printable_name = serializers.SerializerMethodField()
 
     @staticmethod
@@ -649,18 +654,9 @@ class PortfolioGrantCreateSerializer(serializers.ModelSerializer):
         read_only_fields = ("ends_at",)
 
 
-class InviteeWithCCSerializer(InviteeSerializer):
-
-    email = serializers.ListField(
-        child=serializers.EmailField(),
-        required=False, default=list,
-        help_text=_("Email addresses for the invitee. The first email"
-            " is the primary recipient, subsequent ones are CC'd"))
-
-
 class PortfolioRequestCreateSerializer(serializers.ModelSerializer):
 
-    accounts = InviteeWithCCSerializer(many=True)
+    accounts = InviteeSerializer(many=True)
     campaign = serializers.SlugRelatedField(required=False,
         queryset=Campaign.objects.all(), slug_field='slug')
     ends_at = serializers.DateTimeField(required=False, allow_null=True,


### PR DESCRIPTION
I made the assumption that when user uses "re-send" feature we should not create new `PortfolioDoubleOptIn` objects for the provided recipients. 